### PR TITLE
Add ofi-old-psm2.patch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ PATCHES =
 ifneq ($(findstring GASNet-2022.9,$(GASNET_VERSION)),)
 # ofi-warning.patch silences a harmless warning for ofi-conduit/Omni-Path on 2022.9.[02]
 PATCHES += patches/ofi-warning.patch
+# ofi-old-psm2.patch fixes support for libfabric < 1.10 for ofi-conduit/Omni-Path on 2022.9.[02]
+PATCHES += patches/ofi-old-psm2.patch
 endif
 
 ifeq ($(findstring daint,$(shell uname -n)),daint)

--- a/patches/ofi-old-psm2.patch
+++ b/patches/ofi-old-psm2.patch
@@ -1,0 +1,19 @@
+diff --git a/ofi-conduit/gasnet_ofi.c b/ofi-conduit/gasnet_ofi.c
+index 2a4987d3f..5d1e14be7 100644
+--- a/ofi-conduit/gasnet_ofi.c
++++ b/ofi-conduit/gasnet_ofi.c
+@@ -965,7 +965,13 @@ int gasnetc_ofi_init(void)
+     hints->caps |= FI_HMEM;
+   }
+ #endif
+-  hints->mode = 0;  // in particular we do not support FI_CONTEXT due to many-to-one iop
++
++  // We do not support FI_CONTEXT for an RMA endpoint due to many-to-one iop.
++  // However, we must set the bit as a work-around for psm2 provider in libfabric < 1.10 (bug 4567)
++  int have_bug_4567 = using_psm_provider &&
++                      (FI_VERSION(FI_MAJOR_VERSION, FI_MINOR_VERSION) < FI_VERSION(1, 10));
++  hints->mode = have_bug_4567 ? FI_CONTEXT : 0;
++  GASNETI_TRACE_PRINTF(I,("Work-around for bug 4567 is %sabled.", have_bug_4567?"en":"dis"));
+ 
+   ret = fi_getinfo(OFI_CONDUIT_VERSION, NULL, NULL, 0ULL, hints, &gasnetc_rma_info);
+   GASNETC_OFI_CHECK_RET(ret, "fi_getinfo() failed querying for RMA endpoint");


### PR DESCRIPTION
This patch fixes compatibility with libfabric prior to 1.10.0 for ofi-conduit on Omni-Path.
This defect appears in the GASNet 2022.9.[02] releases.

Details:
https://gasnet-bugs.lbl.gov/bugzilla/show_bug.cgi?id=4567