### PR TITLE
Set Aries max medium to 16320

### DIFF
--- a/configs/config.aries.release
+++ b/configs/config.aries.release
@@ -9,3 +9,5 @@
 
 --enable-pshm
 --enable-mpi-compat
+
+--with-aries-max-medium=16320


### PR DESCRIPTION
This is a workaround for https://github.com/StanfordLegion/legion/issues/1449. In the longer term, Realm needs to break up its medium active messages as noted in https://github.com/StanfordLegion/legion/issues/1229, but it seems that even then it is likely that 4K (the default max medium on Aries) is a bit too short for optimum usage, so setting a higher default here (`(1<<14)-64`) makes sense.