### PR TITLE
Enable (CUDA/HIP) memory kind detection on Slingshot 11 networks

### DIFF
--- a/configs/config.ofi-slingshot11.release
+++ b/configs/config.ofi-slingshot11.release
@@ -14,3 +14,4 @@
 --with-ofi-spawner=pmi
 --with-mpi-cc=cc
 --with-pmi-version=cray
+--enable-memory-kinds


### PR DESCRIPTION
Summarizing my understanding of the discussion in #23:

 * This flag will enable *detection* of CUDA/HIP memory kinds on Slingshot 11 networks.
 * Because we expect these systems to generally well-managed and relatively few in number, we're not too worried about side effects from making this a Slingshot 11-wide configuration option. In theory, a misconfigured system could have problems if the detection script found CUDA/HIP but then the driver wasn't actually available on the compute node. (However, even then, if Realm creates 0 GPUs, then we might still be fine?)
 * Aurora might be an issue but since the machine is unavailable for the moment it's not exactly a pressing matter. Worst-case (if Aurora misdetects), I would create separate `-cuda` and `-hip` options here.