### PR TITLE
Add specific configurations for GPU kinds on Slingshot 11 networks

### DIFF
--- a/configs/config.ibv-cuda.release
+++ b/configs/config.ibv-cuda.release
@@ -1,0 +1,14 @@
+--enable-segment-fast
+--enable-par
+--disable-seq
+--disable-parsync
+--enable-pthreads
+
+--disable-auto-conduit-detect
+--enable-ibv
+
+--enable-pshm
+--enable-mpi-compat
+
+--with-ibv-max-hcas=4
+--enable-kind-cuda-uva

--- a/configs/config.ibv-hip.release
+++ b/configs/config.ibv-hip.release
@@ -1,0 +1,14 @@
+--enable-segment-fast
+--enable-par
+--disable-seq
+--disable-parsync
+--enable-pthreads
+
+--disable-auto-conduit-detect
+--enable-ibv
+
+--enable-pshm
+--enable-mpi-compat
+
+--with-ibv-max-hcas=4
+--enable-kind-hip

--- a/configs/config.ibv-no-gpu.release
+++ b/configs/config.ibv-no-gpu.release
@@ -1,0 +1,13 @@
+--enable-segment-fast
+--enable-par
+--disable-seq
+--disable-parsync
+--enable-pthreads
+
+--disable-auto-conduit-detect
+--enable-ibv
+
+--enable-pshm
+--enable-mpi-compat
+
+--with-ibv-max-hcas=4

--- a/configs/config.ofi-slingshot11-cuda.release
+++ b/configs/config.ofi-slingshot11-cuda.release
@@ -1,0 +1,17 @@
+--enable-segment-fast
+--enable-par
+--disable-seq
+--disable-parsync
+--enable-pthreads
+
+--disable-auto-conduit-detect
+--enable-ofi
+
+--enable-pshm
+--enable-mpi-compat
+
+--with-ofi-provider=cxi
+--with-ofi-spawner=pmi
+--with-mpi-cc=cc
+--with-pmi-version=cray
+--enable-kind-cuda-uva

--- a/configs/config.ofi-slingshot11-hip.release
+++ b/configs/config.ofi-slingshot11-hip.release
@@ -1,0 +1,17 @@
+--enable-segment-fast
+--enable-par
+--disable-seq
+--disable-parsync
+--enable-pthreads
+
+--disable-auto-conduit-detect
+--enable-ofi
+
+--enable-pshm
+--enable-mpi-compat
+
+--with-ofi-provider=cxi
+--with-ofi-spawner=pmi
+--with-mpi-cc=cc
+--with-pmi-version=cray
+--enable-kind-hip

--- a/configs/config.ofi-slingshot11-levelzero.release
+++ b/configs/config.ofi-slingshot11-levelzero.release
@@ -1,0 +1,17 @@
+--enable-segment-fast
+--enable-par
+--disable-seq
+--disable-parsync
+--enable-pthreads
+
+--disable-auto-conduit-detect
+--enable-ofi
+
+--enable-pshm
+--enable-mpi-compat
+
+--with-ofi-provider=cxi
+--with-ofi-spawner=pmi
+--with-mpi-cc=cc
+--with-pmi-version=cray
+--enable-kind-ze

--- a/configs/config.ofi-slingshot11-no-gpu.release
+++ b/configs/config.ofi-slingshot11-no-gpu.release
@@ -1,0 +1,16 @@
+--enable-segment-fast
+--enable-par
+--disable-seq
+--disable-parsync
+--enable-pthreads
+
+--disable-auto-conduit-detect
+--enable-ofi
+
+--enable-pshm
+--enable-mpi-compat
+
+--with-ofi-provider=cxi
+--with-ofi-spawner=pmi
+--with-mpi-cc=cc
+--with-pmi-version=cray


### PR DESCRIPTION
This is an attempt to redo #26 while hopefully avoiding the pitfalls that users have seen so far. There will now be four system configurations:

 * `ofi-slingshot11-no-gpu`: Will never enable GPU kinds (was previously called `ofi-slingshot11`)
 * `ofi-slingshot11-cuda`: Will enable kind `cuda-uva` (and force an error if this doesn't work)
 * `ofi-slingshot11-hip`: Will enable kind `hip` (and force an error if this doesn't work)
 * `ofi-slingshot11-levelzero`: Will enable kind `ze` (and force an error if this doesn't work)

Since we haven't been able to reliably turn on memory kinds all the time, and even when they are turned on it can be a bit tricky to use correctly (since Slingshot 11 systems seemingly cannot pin all GPUs' memory with a single NIC), this helps users by explicitly opting in to the GPU memory kind that they want. Once they enable that configuration, everything else should be a hard error so hopefully that will force us to be on the fast path from that point on.

It will still be possible for users to simply forget to turn on GPU kinds at all; but given the current difficulties I think we cannot enable it by default yet. I am in discussions to see if we can enable better diagnostics to help users figure out when they have forgotten to enable an available GPU memory kind.