### PR TITLE
Add hwloc.patch to fix core binding issue exposed by OFI CXI provider

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,10 @@ GASNET_VERSION ?= GASNet-2024.5.0
 # these patches are applied to the unpacked GASNet source directory before
 #  running configure
 PATCHES =
+ifneq ($(findstring GASNet-2024.5,$(GASNET_VERSION)),)
+# hwloc.patch fixes an issue with core binding that appears on the OFI CXI provider
+PATCHES += patches/hwloc.patch
+endif
 ifneq ($(findstring GASNet-2022.9,$(GASNET_VERSION)),)
 # ofi-warning.patch silences a harmless warning for ofi-conduit/Omni-Path on 2022.9.[02]
 PATCHES += patches/ofi-warning.patch

--- a/patches/hwloc.patch
+++ b/patches/hwloc.patch
@@ -1,0 +1,11 @@
+--- a/other/hwloc/gasnet_hwloc.c
++++ b/other/hwloc/gasnet_hwloc.c
+@@ -365,7 +365,7 @@ char *gasneti_getenv_hwloc_withdefault(const char *keyname, const char *dflt_val
+     cpuset = hwloc_bitmap_alloc();
+     if (!cpuset ||
+         (hwloc_topology_load(topology) < 0) ||
+-        (hwloc_get_cpubind(topology, cpuset, HWLOC_CPUBIND_PROCESS) < 0 )) {
++        (hwloc_get_cpubind(topology, cpuset, HWLOC_CPUBIND_THREAD) < 0 )) {
+       // failed to query cpu binding from hwloc
+       goto out_bad_cpuset;
+     }


### PR DESCRIPTION
Applying a patch by @PHHargrove to fix HWLOC core binding detection in the current GASNet release 2024.5.0. This is required to correctly use `GASNET_OFI_DEVICE_TYPE=Node` to bind NICs with the OFI CXI provider.

Some additional context about the issue is available in the following PR, which is **NOT** included in 2024.5.0 (or the attached patch), but may be included in a future GASNet release:

https://bitbucket.org/berkeleylab/gasnet/pull-requests/635/