### PR TITLE
Add patches to fix GASNet bugs 4752 and 4753 on OFI conduit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,9 @@ PATCHES =
 ifneq ($(findstring GASNet-2024.5,$(GASNET_VERSION)),)
 # hwloc.patch fixes an issue with core binding that appears on the OFI CXI provider
 PATCHES += patches/hwloc.patch
+# The following two patches address GASNet bugs 4752 and 4753 on the OFI conduit
+PATCHES += patches/ofi-recvmsg-retry.patch
+PATCHES += patches/ofi-race.patch
 endif
 ifneq ($(findstring GASNet-2022.9,$(GASNET_VERSION)),)
 # ofi-warning.patch silences a harmless warning for ofi-conduit/Omni-Path on 2022.9.[02]

--- a/patches/ofi-race.patch
+++ b/patches/ofi-race.patch
@@ -1,0 +1,37 @@
+From bc3e692a96be360b28c794e657def97367575191 Mon Sep 17 00:00:00 2001
+From: "Paul H. Hargrove" <PHHargrove@lbl.gov>
+Date: Thu, 3 Oct 2024 16:12:42 -0700
+Subject: [PATCH] ofi: correct race on final_cntr (bug 4753)
+
+This commit corrects the race condition reported in bug 4753 by
+ensuring that the read of `header->final_cntr` can never observe a
+value older than the atomic increment of `header->consumed_cntr`.
+
+Resolves bug 4753:
+"ofi: race condition in multi-receive message accounting"
+---
+ ofi-conduit/gasnet_ofi.c | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/ofi-conduit/gasnet_ofi.c b/ofi-conduit/gasnet_ofi.c
+index 789edfd85..8f3daf8ef 100644
+--- a/ofi-conduit/gasnet_ofi.c
++++ b/ofi-conduit/gasnet_ofi.c
+@@ -2392,9 +2392,12 @@ void gasnetc_ofi_am_recv_poll(int is_request)
+ 
+         // Repost if either not using FI_MULTI_RECV
+         // OR matched "final" and "consumed" counters indicate last AM handler has completed
++        uint64_t consumed;
+         if (!maybe_multi_recv ||
+-            ((GASNETI_ATOMIC_MAX & header->final_cntr) ==
+-             (uint64_t) gasnetc_paratomic_add(&header->consumed_cntr, 1, GASNETI_ATOMIC_ACQ))) {
++            // Note: use of ACQ fence and comma operator ensure the read of final_cntr
++            // cannot be "stale" relative to the increment of consumed_cntr.
++            ((consumed = gasnetc_paratomic_add(&header->consumed_cntr, 1, GASNETI_ATOMIC_ACQ)),
++             ((GASNETI_ATOMIC_MAX & header->final_cntr) == consumed))) {
+             struct fi_msg* am_buff_msg = &metadata->am_buff_msg;
+             GASNETC_OFI_LOCK(&gasnetc_ofi_locks.am_rx);
+             int post_ret = fi_recvmsg(ep, am_buff_msg, maybe_multi_recv);
+-- 
+2.46.2
+

--- a/patches/ofi-recvmsg-retry.patch
+++ b/patches/ofi-recvmsg-retry.patch
@@ -1,0 +1,82 @@
+From 67b51846de4bf2bb2d38eaf4a42e66163494a60d Mon Sep 17 00:00:00 2001
+From: "Paul H. Hargrove" <PHHargrove@lbl.gov>
+Date: Tue, 1 Oct 2024 13:13:34 -0700
+Subject: [PATCH] ofi: fix fi_recvmsg() retry logic (bug 4752)
+
+This commit corrects a critical flaw (reported as bug 4752) in the
+logic to deal with an `FI_EAGAIN` return from `fi_recvmsg()` when
+reposting an AM receive buffer.  The original issue was reported as
+bug 4376 which was resolved as FIXED with the merge of PR#519, first
+appearing in the 2022.3.0 release.
+
+The original code was intended to retry posts of buffers held on a
+retry list on *every* call to `gasnetc_ofi_am_recv_poll()`.  However,
+the loop over multiple calls to `fi_cq_read()` would terminate via
+`return` if there were less than `GASNETC_OFI_EVENTS_PER_POLL` events
+to reap from the Cq (16 by default) OR if `GASNETC_OFI_PAR_TRYLOCK()`
+found the lock to be held by another thread.  As a result, even in a
+run without thread contention, the critical reposting operation was
+only reachable in the presence of sufficient bursts of Cq event
+(corresponding to inbound AMs).
+
+Subsequent to the initial work around, commit 28af0fd90b added tracing
+and stats, which replaced the `return` with `goto out`.  While a
+correctly placed `out:` would have resolved the current defect, it was
+instead placed in a way which preserved the (flawed) behavior in which
+`fi_recvmsg()` retries are skipped on early termination of the loop
+over `fi_cq_read()`.
+
+This commit replaces use of `goto` with `break`, except in the case we
+detect that an exit is in progress (since reposting might risk making
+an exit-on-error worse).  This use of `break` should be more robust to
+future human error, since it more clearly indicates the intent to
+terminate (only) the loop early.  This might be marginally more
+friendly to compiler analysis as well.
+
+Resolves bug 4752: "Incomplete work-around for bug 4376 (FI_EAGAIN
+when reposting multi-recv buffer)"
+---
+ ofi-conduit/gasnet_ofi.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/ofi-conduit/gasnet_ofi.c b/ofi-conduit/gasnet_ofi.c
+index c820c35f3..c8e1d6224 100644
+--- a/ofi-conduit/gasnet_ofi.c
++++ b/ofi-conduit/gasnet_ofi.c
+@@ -2339,7 +2339,7 @@ void gasnetc_ofi_am_recv_poll(int is_request)
+ 
+     int count;
+     for (count = 0; count < GASNETC_OFI_EVENTS_PER_POLL; ++count) {
+-        if(EBUSY == GASNETC_OFI_PAR_TRYLOCK(lock_p)) goto out;
++        if(EBUSY == GASNETC_OFI_PAR_TRYLOCK(lock_p)) break;
+ 
+         /* Read from Completion Queue */
+         struct fi_cq_data_entry re = {0};
+@@ -2347,13 +2347,13 @@ void gasnetc_ofi_am_recv_poll(int is_request)
+ 
+         if (ret == -FI_EAGAIN) {
+             GASNETC_OFI_PAR_UNLOCK(lock_p);
+-            goto out;
++            break;
+         } 
+         if_pf (ret < 0) {
+             struct fi_cq_err_entry e = {0};
+             gasnetc_fi_cq_readerr(cq, &e ,0);
+             GASNETC_OFI_PAR_UNLOCK(lock_p);
+-            if_pf (gasnetc_is_exit_error(e)) goto out;
++            if_pf (gasnetc_is_exit_error(e)) goto error_out;
+             gasnetc_ofi_fatalerror("fi_cq_read for am_recv_poll failed with error", -e.err);
+         }
+ 
+@@ -2456,7 +2456,7 @@ void gasnetc_ofi_am_recv_poll(int is_request)
+     }
+ #endif
+ 
+-out:
++error_out:
+     if (is_request) {
+         GASNETI_TRACE_EVENT_VAL(X, CQ_READ_REQ, count);
+     } else {
+-- 
+2.46.2
+


### PR DESCRIPTION
This PR adds patches for GASNet bugs 4752 and 4753 that impact the behavior of the OFI conduit and ability for GASNet to properly reuse buffers. These patches are cherry-picked from the following two GASNet commits:

 * https://bitbucket.org/berkeleylab/gasnet/commits/67b51846de4bf2bb2d38eaf4a42e66163494a60d
 * https://bitbucket.org/berkeleylab/gasnet/commits/bc3e692a96be360b28c794e657def97367575191

In some applications and configurations this may resolve freezes observed on the HPE Slingshot 11 network.