### PR TITLE
Fixup the cuda FB memory registration with GASNetEX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,8 @@ PATCHES += patches/hwloc.patch
 # The following two patches address GASNet bugs 4752 and 4753 on the OFI conduit
 PATCHES += patches/ofi-recvmsg-retry.patch
 PATCHES += patches/ofi-race.patch
+# The following patch address the GASNet bug 4767 regarding registering cuMemMap memory 
+# https://gasnet-bugs.lbl.gov/bugzilla/show_bug.cgi?id=4767
 PATCHES += patches/cumemmap.patch
 endif
 ifneq ($(findstring GASNet-2022.9,$(GASNET_VERSION)),)

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ PATCHES += patches/hwloc.patch
 # The following two patches address GASNet bugs 4752 and 4753 on the OFI conduit
 PATCHES += patches/ofi-recvmsg-retry.patch
 PATCHES += patches/ofi-race.patch
+PATCHES += patches/cumemmap.patch
 endif
 ifneq ($(findstring GASNet-2022.9,$(GASNET_VERSION)),)
 # ofi-warning.patch silences a harmless warning for ofi-conduit/Omni-Path on 2022.9.[02]

--- a/patches/cumemmap.patch
+++ b/patches/cumemmap.patch
@@ -1,14 +1,34 @@
 diff --git a/other/kinds/gasnet_cuda_uva.c b/other/kinds/gasnet_cuda_uva.c
-index d1d7bd8be..5d2bbf4b7 100644
+index d1d7bd8..ece8f44 100644
 --- a/other/kinds/gasnet_cuda_uva.c
 +++ b/other/kinds/gasnet_cuda_uva.c
-@@ -112,7 +112,8 @@ static int gasneti_MK_Segment_Create_cuda_uva(
+@@ -73,6 +73,7 @@ static int gasneti_MK_Segment_Create_cuda_uva(
+   CUresult result;
+   void * to_free = NULL;
+   int retval = GASNET_OK;
++  int use_sync_memops = kind->use_sync_memops;
+
+   gasneti_check_cudacall(cuCtxPushCurrent(kind->ctx));
+
+@@ -109,6 +110,12 @@ static int gasneti_MK_Segment_Create_cuda_uva(
+     // We currently accept memory allocated by *any* context for the same device.
+     // TODO: should we be more strict by checking equality of contexts instead of devices?
+     CUdevice dev;
++    if (ctx == NULL) {
++      // No context, even though other attributres are OK.
++      // This would occur, for instance, with a cuMemMap() (which does
++      // not support the SYNC_MEMOPS attribute).  See bug TBD.
++      use_sync_memops = 0;
++    } else
      if ((result = cuCtxPushCurrent(ctx)) ||
          (result = cuCtxGetDevice(&dev))  ||
          (result = cuCtxPopCurrent(&ctx))) {
--      gasneti_fatalerror("Failed to query CUDA device of client-allocated memory: "
-+      gasneti_console_message("WARNING",
-+                         "Failed to query CUDA device of client-allocated memory: "
-                          GASNETI_CURESULT_FMT, GASNETI_CURESULT_STRING(result));
-     } else if (dev != kind->dev) {
-       gasneti_fatalerror("gex_Segment_Create(CUDA_UVA) with memory associated with wrong device");
+@@ -131,7 +138,7 @@ static int gasneti_MK_Segment_Create_cuda_uva(
+     addr = to_free = (void *) dptr;
+   }
+
+-  if (kind->use_sync_memops) {
++  if (use_sync_memops) {
+     int one = 1;
+     gasneti_check_cudacall(cuPointerSetAttribute(&one, CU_POINTER_ATTRIBUTE_SYNC_MEMOPS, dptr));
+   }

--- a/patches/cumemmap.patch
+++ b/patches/cumemmap.patch
@@ -1,0 +1,14 @@
+diff --git a/other/kinds/gasnet_cuda_uva.c b/other/kinds/gasnet_cuda_uva.c
+index d1d7bd8be..5d2bbf4b7 100644
+--- a/other/kinds/gasnet_cuda_uva.c
++++ b/other/kinds/gasnet_cuda_uva.c
+@@ -112,7 +112,8 @@ static int gasneti_MK_Segment_Create_cuda_uva(
+     if ((result = cuCtxPushCurrent(ctx)) ||
+         (result = cuCtxGetDevice(&dev))  ||
+         (result = cuCtxPopCurrent(&ctx))) {
+-      gasneti_fatalerror("Failed to query CUDA device of client-allocated memory: "
++      gasneti_console_message("WARNING",
++                         "Failed to query CUDA device of client-allocated memory: "
+                          GASNETI_CURESULT_FMT, GASNETI_CURESULT_STRING(result));
+     } else if (dev != kind->dev) {
+       gasneti_fatalerror("gex_Segment_Create(CUDA_UVA) with memory associated with wrong device");


### PR DESCRIPTION
The bug: https://gasnet-bugs.lbl.gov/bugzilla/show_bug.cgi?id=4767

After CUDA 11.5, Realm uses cuMemMap to allocate FB memory, and it triggers an error when register the memory with GASNetEX for GPUDirect. This PR fixes the error. 